### PR TITLE
feat: 칵테일 공식레시피 상세조회 기능 구현

### DIFF
--- a/back/src/main/java/com/group4/aldalka/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/group4/aldalka/domain/post/controller/PostController.java
@@ -19,19 +19,19 @@ public class PostController
     private final PostService postService;
 
     //비회원, 회원 모두 접근가능
-    @PostMapping("")
-    public ResponseEntity<ResultResponse> searchPosts(@LoginUser String userId, @RequestBody PostSearchRequest postRequest) {
+    @PostMapping("/search")
+    public ResponseEntity<ResultResponse> searchPosts(@LoginUser String username, @RequestBody PostSearchRequest postRequest) {
         postRequest.applyDefaults();
         return ResponseEntity.ok(
-                ResultResponse.of(GET_POST_INFO_SUCCESS, postService.searchPosts(userId, postRequest))
+                ResultResponse.of(GET_POST_INFO_SUCCESS, postService.searchPosts(username, postRequest))
         );
     }
 
     //비회원, 회원 모두 접근가능
-    @GetMapping("")
-    public ResponseEntity<ResultResponse> getOfficialPostDetail(@LoginUser String userId, @PathVariable Long postId){
+    @GetMapping("/{postId}")
+    public ResponseEntity<ResultResponse> getOfficialPostDetail(@LoginUser String username, @PathVariable Long postId){
         return ResponseEntity.ok(
-                ResultResponse.of(GET_OFFICIAL_DETAIL_INFO_SUCCESS, postService.getOfficialPostDetail(userId, postId))
+                ResultResponse.of(GET_OFFICIAL_DETAIL_INFO_SUCCESS, postService.getOfficialPostDetail(username, postId))
         );
     }
 }

--- a/back/src/main/java/com/group4/aldalka/domain/post/controller/PostController.java
+++ b/back/src/main/java/com/group4/aldalka/domain/post/controller/PostController.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import static com.group4.aldalka.global.result.ResultCode.GET_POST_INFO_SUCCESS;
+import static com.group4.aldalka.global.result.ResultCode.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +24,14 @@ public class PostController
         postRequest.applyDefaults();
         return ResponseEntity.ok(
                 ResultResponse.of(GET_POST_INFO_SUCCESS, postService.searchPosts(userId, postRequest))
+        );
+    }
+
+    //비회원, 회원 모두 접근가능
+    @GetMapping("")
+    public ResponseEntity<ResultResponse> getOfficialPostDetail(@LoginUser String userId, @PathVariable Long postId){
+        return ResponseEntity.ok(
+                ResultResponse.of(GET_OFFICIAL_DETAIL_INFO_SUCCESS, postService.getOfficialPostDetail(userId, postId))
         );
     }
 }

--- a/back/src/main/java/com/group4/aldalka/domain/post/dto/OfficialPostDetailResponse.java
+++ b/back/src/main/java/com/group4/aldalka/domain/post/dto/OfficialPostDetailResponse.java
@@ -1,0 +1,48 @@
+package com.group4.aldalka.domain.post.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // Jackson 역직렬화를 위해 기본생성자 필요, 외부 호출 차단
+@AllArgsConstructor
+@Builder
+public class OfficialPostDetailResponse {
+
+    @JsonProperty("post_id")
+    private Long postId;
+
+    private String title;
+
+    private String content;
+
+    private String recipe;
+
+    private Integer difficulty;
+
+    @JsonProperty("is_shaken")
+    private Boolean isShaken;
+
+    @JsonProperty("created_at")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate createdAt;
+
+    @JsonProperty("like_count")
+    private Integer likeCount;
+
+    @JsonProperty("is_liked")
+    private Boolean isLiked;
+
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    @JsonProperty("base_liqueurs")
+    private List<String> baseLiqueurs;
+
+    private List<String> ingredients;
+
+}

--- a/back/src/main/java/com/group4/aldalka/domain/post/repository/UserLikeRepository.java
+++ b/back/src/main/java/com/group4/aldalka/domain/post/repository/UserLikeRepository.java
@@ -22,5 +22,7 @@ public interface UserLikeRepository extends JpaRepository<UserLike, Long> {
         Long getCount();
     }
 
+    boolean existsByUserUserIdAndPostPostId(Long user_userId, Long post_postId);
+
 }
 

--- a/back/src/main/java/com/group4/aldalka/domain/post/service/PostService.java
+++ b/back/src/main/java/com/group4/aldalka/domain/post/service/PostService.java
@@ -1,9 +1,6 @@
 package com.group4.aldalka.domain.post.service;
 
-import com.group4.aldalka.domain.post.dto.PagedPostResponse;
-import com.group4.aldalka.domain.post.dto.PostResponse;
-import com.group4.aldalka.domain.post.dto.PostSearchRequest;
-import com.group4.aldalka.domain.post.dto.PostSearchResult;
+import com.group4.aldalka.domain.post.dto.*;
 import com.group4.aldalka.domain.post.entity.Post;
 import com.group4.aldalka.domain.post.repository.PostRepository;
 import com.group4.aldalka.domain.post.repository.UserLikeRepository;
@@ -63,5 +60,19 @@ public class PostService {
                         likedSet.contains(post.getPostId())
                 ))
                 .collect(Collectors.toList());
+    }
+
+    public OfficialPostDetailResponse getOfficialPostDetail(String userId, Long postId) {
+
+
+
+
+
+
+
+
+
+
+
     }
 }

--- a/back/src/main/java/com/group4/aldalka/domain/post/service/PostService.java
+++ b/back/src/main/java/com/group4/aldalka/domain/post/service/PostService.java
@@ -4,7 +4,6 @@ import com.group4.aldalka.domain.post.dto.*;
 import com.group4.aldalka.domain.post.entity.Post;
 import com.group4.aldalka.domain.post.repository.PostRepository;
 import com.group4.aldalka.domain.post.repository.UserLikeRepository;
-import com.group4.aldalka.domain.user.User;
 import com.group4.aldalka.domain.user.repository.UserRepository;
 import com.group4.aldalka.global.error.ErrorCode;
 import com.group4.aldalka.global.error.exception.BusinessException;

--- a/back/src/main/java/com/group4/aldalka/domain/post/service/PostService.java
+++ b/back/src/main/java/com/group4/aldalka/domain/post/service/PostService.java
@@ -4,6 +4,10 @@ import com.group4.aldalka.domain.post.dto.*;
 import com.group4.aldalka.domain.post.entity.Post;
 import com.group4.aldalka.domain.post.repository.PostRepository;
 import com.group4.aldalka.domain.post.repository.UserLikeRepository;
+import com.group4.aldalka.domain.user.User;
+import com.group4.aldalka.domain.user.repository.UserRepository;
+import com.group4.aldalka.global.error.ErrorCode;
+import com.group4.aldalka.global.error.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,9 +21,10 @@ import java.util.stream.Collectors;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
     private final UserLikeRepository userLikeRepository;
 
-    public PagedPostResponse searchPosts(String userId, PostSearchRequest postSearchRequest) {
+    public PagedPostResponse searchPosts(String username, PostSearchRequest postSearchRequest) {
 
         PostSearchResult result = postRepository.searchPosts(postSearchRequest);
         int pageSize = 8;
@@ -27,7 +32,7 @@ public class PostService {
 
 
         return PagedPostResponse.builder()
-                .posts(getPostsWithLikeInfo(userId, result.getPosts()))
+                .posts(getPostsWithLikeInfo(username, result.getPosts()))
                 .totalPages(totalPages)
                 .totalElements(result.getTotalElements())
                 .build();
@@ -62,17 +67,47 @@ public class PostService {
                 .collect(Collectors.toList());
     }
 
-    public OfficialPostDetailResponse getOfficialPostDetail(String userId, Long postId) {
+    public OfficialPostDetailResponse getOfficialPostDetail(String username, Long postId) {
 
+        Long userId = userRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_EXISTS))
+                .getUserId();
 
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POST_NOT_FOUND));
 
+        boolean isLiked = false;
+        if (userId != null) isLiked = userLikeRepository.existsByUserUserIdAndPostPostId(userId, postId);
 
+        int likeCount = post.getLikes().size();
 
-
-
-
-
-
-
+        return buildOfficialPostDetailResponse(post, likeCount, isLiked);
     }
+
+    private OfficialPostDetailResponse buildOfficialPostDetailResponse(Post post, int likeCount, boolean isLiked) {
+        List<String> ingredients = post.getPostIndgredients().stream()
+                .map(p -> p.getIngredient().getName())
+                .toList();
+
+        List<String> baseLiqueurs = post.getPostBaseLiquors().stream()
+                .map(b -> b.getBaseLiquor().getName())
+                .toList();
+
+        return OfficialPostDetailResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .recipe(post.getRecipe())
+                .difficulty(post.getDifficulty())
+                .isShaken(post.isShaken())
+                .createdAt(post.getCreatedAt().toLocalDate())
+                .likeCount(likeCount)
+                .isLiked(isLiked)
+                .imageUrl(post.getImageUrl())
+                .baseLiqueurs(baseLiqueurs)
+                .ingredients(ingredients)
+                .build();
+    }
+
+
 }

--- a/back/src/main/java/com/group4/aldalka/global/error/ErrorCode.java
+++ b/back/src/main/java/com/group4/aldalka/global/error/ErrorCode.java
@@ -19,8 +19,11 @@ public enum ErrorCode {
     IS_NOT_IMAGE(400, "이미지가 아닙니다."),
 
     //User
-    USER_NOT_EXISTS(404, "존재하지 않는 회원입니다.");
+    USER_NOT_EXISTS(404, "존재하지 않는 회원입니다."),
 
+
+    //Post
+    POST_NOT_FOUND(404, "존재하지 않는 게시글입니다.");
 
 
     private final int status;

--- a/back/src/main/java/com/group4/aldalka/global/result/ResultCode.java
+++ b/back/src/main/java/com/group4/aldalka/global/result/ResultCode.java
@@ -11,7 +11,10 @@ public enum ResultCode {
     GET_USER_INFO_SUCCESS(200, "회원 정보 조회에 성공하였습니다."),
 
     //포스트
-    GET_POST_INFO_SUCCESS(200, "포스트 정보 조회에 성공하였습니다.");
+    GET_POST_INFO_SUCCESS(200, "포스트 정보 조회에 성공하였습니다."),
+
+    //공식 칵테일 레시피
+    GET_OFFICIAL_DETAIL_INFO_SUCCESS(200, "포스트 정보 조회에 성공하였습니다.");
 
     private final int status;
     private final String message;


### PR DESCRIPTION
# 🔥 Pull Request


## 🔗 관련 이슈 번호

<!--- ex) 이슈 번호를 작성해주세요: Closes #11 -->
- Closes #35 
- 
<br>

## 📌 작업 내용

- 칵테일 공식레시피 상세조회 구현

<br>

## ✅ 변경 사항

- PostController에서 공식 레시피 전체 조회 API 경로를 /search로 리팩터링
- PostController에서 getOfficialPostDetail 메소드 추가
- UserLikeRepository에서 existsByUserUserIdAndPostPostId 메소드 추가

<br>

## 📸 스크린샷 (선택)

<!-- 필요 시 작업 결과 스크린샷을 첨부해주세요 -->

<br>

## 🗨️ 코멘트

- 리뷰 시 참고하거나 봐줬으면 하는 부분이 있다면 작성해주세요.
